### PR TITLE
Add data protection policy, update README, fix UI bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,90 +2,93 @@
 
 A React-based **Forma embedded extension** that detects trees automatically identified using OpenCV from satellite imagery and place them as 3D models directly into your Forma project.
 
-> ⚠️ **Important:** This application is designed to run as an **embedded extension inside Autodesk Forma**. It will not work as a standalone web application. See the [Forma Embedded Views documentation](https://aps.autodesk.com/en/docs/forma/v1/embedded-views/introduction/) to learn how to create and host Forma extensions.
+> **Important:** This application is designed to run as an **embedded extension inside Autodesk Forma**. It will not work as a standalone web application. See the [Forma Embedded Views documentation](https://aps.autodesk.com/en/docs/forma/v1/embedded-views/introduction/) to learn how to create and host Forma extensions.
 
 ![Forma Extension](./public/project_page.png)
 
-## 🎯 Overview
+## Overview
 
 This extension automates the process of detecting and placing trees in Forma projects:
 
 1. **Fetches satellite imagery** aligned with Forma's UTM coordinate system
 2. **Detects trees** using HSV color segmentation
 3. **Calculates tree dimensions** (diameter and height) from detected canopy sizes
-4. **Places 3D tree models** directly into your Forma project using efficient instancing
+4. **Places 3D tree models** directly into your Forma project using batch placement
 5. **Scales trees automatically** based on detected diameter (realistic proportions)
 
 ### Key Capabilities
 
 | Feature | Description |
 |---------|-------------|
-| 🌳 **Automatic Tree Detection** | Satellite imagery analysis to find trees |
-| 📏 **Per-Tree Scaling** | Each tree is scaled based on its detected canopy diameter |
-| ⚡ **High-Performance Placement** | 40+ trees/second using instance mode |
-| 🗺️ **Extended Coverage** | Detect trees beyond Forma's ~2km terrain limit |
-| 🔐 **User Authentication** | Directus-based auth with project tracking |
-| 📊 **Project Management** | Track and manage your Forma projects |
+| **Automatic Tree Detection** | Satellite imagery analysis to find trees |
+| **Per-Tree Scaling** | Each tree is scaled based on its detected canopy diameter |
+| **High-Performance Placement** | ~3,000 trees in ~10 seconds using batch `updateElements` API |
+| **Extended Coverage** | Detect trees beyond Forma's ~2km terrain limit |
+| **User Authentication** | Directus-based auth with project tracking |
+| **Large OBJ Export** | Two-step streaming download — handles 242MB+ models |
+| **Project Management** | Track and manage your Forma projects |
 
 ![Tree Placement in Action](public/TreePlacement.gif)
 
-## 🏗️ Architecture Overview
+## Architecture Overview
 
 ```
-┌─────────────────────────────────────────────────────────────────────┐
-│                         FORMA (Host Application)                    │
-│  ┌───────────────────────────────────────────────────────────────┐  │
-│  │                    Embedded Extension (iframe)                │  │
-│  │  ┌─────────────────────────────────────────────────────────┐  │  │
-│  │  │              React Frontend (Vite + TypeScript)         │  │  │
-│  │  │   • Tree Detection UI    • Satellite Tile Viewer        │  │  │
-│  │  │   • Project Management   • User Menu & Navigation       │  │  │
-│  │  └─────────────────────────────────────────────────────────┘  │  │
-│  └───────────────────────────────────────────────────────────────┘  │
-└─────────────────────────────────────────────────────────────────────┘
-                                    │
-                                    ▼
-┌─────────────────────────────────────────────────────────────────────┐
-│                    Express Backend (Node.js)                        │
-│  • Authentication (Directus integration)                            │
-│  • Session management                                               │
-│  • API proxy to Python backend                                      │
-│  • Serves React static files in production                          │
-│  Port: 3001                                                         │
-└─────────────────────────────────────────────────────────────────────┘
-                                    │
-                                    ▼
-┌─────────────────────────────────────────────────────────────────────┐
-│                    Python Backend (FastAPI)                         │
-│  • Tree detection (OpenCV + HSV segmentation)                       │
-│  • 3D model generation (OBJ/GLB export)                             │
-│  • Image processing                                                 │
-│  Port: 5001                                                         │
-└─────────────────────────────────────────────────────────────────────┘
-                                    │
-                                    ▼
-┌─────────────────────────────────────────────────────────────────────┐
-│                    Directus (External CMS)                          │
-│  • User authentication & management                                 │
-│  • Project tracking database                                        │
-│  • User-project relationships                                       │
-└─────────────────────────────────────────────────────────────────────┘
++---------------------------------------------------------------------+
+|                         FORMA (Host Application)                    |
+|  +---------------------------------------------------------------+  |
+|  |                    Embedded Extension (iframe)                |  |
+|  |  +---------------------------------------------------------+  |  |
+|  |  |              React Frontend (Vite + TypeScript)         |  |  |
+|  |  |   - Tree Detection UI    - Satellite Tile Viewer        |  |  |
+|  |  |   - Project Management   - User Menu & Navigation       |  |  |
+|  |  +---------------------------------------------------------+  |  |
+|  +---------------------------------------------------------------+  |
++---------------------------------------------------------------------+
+                                    |
+                                    v
++---------------------------------------------------------------------+
+|                    Express Backend (Node.js)                        |
+|  - Authentication (Directus integration)                            |
+|  - Session management                                               |
+|  - API proxy to Python backend                                      |
+|  - Serves React static files in production                          |
+|  - Streams large OBJ downloads from Python to client                |
+|  Port: 3001                                                         |
++---------------------------------------------------------------------+
+                                    |
+                                    v
++---------------------------------------------------------------------+
+|                    Python Backend (FastAPI)                         |
+|  - Tree detection (OpenCV + HSV segmentation)                       |
+|  - 3D model generation (OBJ export to temp files)                   |
+|  - Model download endpoint (FileResponse streaming)                 |
+|  - Image processing                                                 |
+|  Port: 5001                                                         |
++---------------------------------------------------------------------+
+                                    |
+                                    v
++---------------------------------------------------------------------+
+|                    Directus (External CMS)                          |
+|  - User authentication & management                                 |
+|  - Project tracking database                                        |
+|  - User-project relationships                                       |
++---------------------------------------------------------------------+
 ```
 
-## 🛠️ Technical Stack
+## Technical Stack
 
 | Layer | Technology |
 |-------|------------|
-| **Frontend** | React 18 + TypeScript + Vite |
+| **Frontend** | React 19 + TypeScript + Vite |
 | **Forma Integration** | `forma-embedded-view-sdk/auto` |
 | **Backend (API)** | Node.js + Express |
-| **Backend Proxy** | Python + FastAPI + OpenCV |
+| **Backend (Detection)** | Python + FastAPI + OpenCV |
 | **Authentication** | Directus CMS (or local auth for testing) |
 | **Coordinate Transforms** | proj4 |
 | **Map Provider** | Mapbox Raster Tiles API |
 | **Containerization** | Docker + Docker Compose |
 
-## 📋 Prerequisites
+## Prerequisites
 
 - **Docker** and **Docker Compose** (recommended for easy setup)
 - **Mapbox Access Token** ([Get one here](https://account.mapbox.com/))
@@ -98,16 +101,16 @@ This extension automates the process of detecting and placing trees in Forma pro
 - Python 3.11+
 - npm or yarn
 
-## 🔧 Installation & Setup
+## Installation & Setup
 
-### Option 1: Docker (Recommended) 🐳
+### Option 1: Docker (Recommended)
 
 The easiest way to run the application is using Docker containers.
 
 **1. Clone the repository:**
 ```bash
-git clone https://github.com/ABCHai25/Forma-Project-Info.git
-cd Forma-Project-Info
+git clone https://github.com/henn-dt/forma-extension-trees.git
+cd forma-extension-trees
 ```
 
 **2. Create environment file:**
@@ -147,12 +150,29 @@ docker-compose up -d
 docker-compose down
 ```
 
+#### Linking to Autodesk Forma
+
+Once the service is running, you need to register it as an embedded view in your Forma project:
+
+1. Go to the [Autodesk Forma Extensions page](https://aps.autodesk.com/en/docs/forma/v1/embedded-views/introduction/) for full documentation.
+2. In your Forma project, open **Extensions** from the left sidebar.
+3. Click **Add Extension** and select **Embedded View**.
+4. Enter your extension URL:
+   - **Local development:** `http://localhost:3001`
+   - **Production:** your deployed URL (e.g. `https://webapps.henn.com/forma-tree`)
+5. Give it a name (e.g. "Tree Detection") and save.
+6. The extension will now appear in Forma's right-side panel.
+
+For a step-by-step walkthrough, see the official tutorial: [Creating Embedded Views in Forma](https://tutorials.autodesk.com/courses/forma-extensions-tutorial).
+
+> **Note:** For production deployments served over HTTPS inside Forma's iframe, make sure `ALLOWED_ORIGINS` in your `.env` includes Forma's origin (e.g. `https://app.autodeskforma.eu`) and that session cookies are configured with `SESSION_COOKIE_SECURE=true` and `SESSION_COOKIE_SAMESITE=none`.
+
 ### Option 2: Local Development
 
 **1. Clone and install dependencies:**
 ```bash
-git clone https://github.com/ABCHai25/Forma-Project-Info.git
-cd Forma-Project-Info
+git clone https://github.com/henn-dt/forma-extension-trees.git
+cd forma-extension-trees
 
 # Frontend dependencies
 npm install
@@ -200,32 +220,31 @@ Terminal 3 - React Frontend:
 npm run dev
 ```
 
-## 🔐 Authentication System
+## Authentication System
 
 This extension uses **Directus** as the authentication and project management backend. Users must log in before accessing the tree detection features.
 
 ### Authentication Flow
 
 ![Registration Page](./public/auth-reg.png)
-*New users can register with email and password*
+*New users can register with email and password. Registration includes a GDPR data consent checkbox — users must agree to the storage of their personal data before creating an account.*
 
 ![Login Page](./public/auth-page.png)
-*Existing users log in with their credentials*
+*Existing users log in with their credentials. Password fields include a visibility toggle.*
 
 ![Welcome Page](./public/auth-welcome.png)
 *After login, users see a welcome page before entering the app*
 
-### User Menu & Navigation
+### User Menu & Projects Panel
 
 Once logged in, users have access to a dropdown menu:
 
 ![User Menu](./public/menu1.png)
 
 The menu provides:
-- **🏠 Home** - Return to the main tree detection interface
-- **👤 User Information** - View your account details
-- **📁 My Projects** - View all Forma projects you've worked on
-- **🚪 Logout** - Sign out of the application
+- **User Information** - View your account details
+- **My Projects** - Opens a slide-in drawer panel showing all Forma projects you've worked on
+- **Logout** - Sign out of the application
 
 ### Project Tracking
 
@@ -240,16 +259,24 @@ The extension automatically logs Forma projects to Directus when you click "Get 
 
 If you don't have a Directus instance, you can use the local authentication template:
 
-👉 **[Henn Auth Template](https://github.com/ABCHai25/Henn_Auth_Template)**
+**[Henn Auth Template](https://github.com/ABCHai25/Henn_Auth_Template)**
 
 This provides a simple local auth system for development and testing purposes.
 
-## 📖 Usage Guide
+### Known Limitation: Directus Vendor Lock-in
+
+> **Future Work:** The current authentication and project tracking system is tightly coupled to **Directus CMS**. This means anyone who clones the repo must set up and configure a Directus instance before the auth features work at all — a significant barrier for contributors and new team members.
+>
+> **Planned:** Replace the Directus dependency with a local **SQLite** database as an automatic fallback. When `DIRECTUS_URL` is not set in `.env`, the backend will auto-create a local database file and use that instead, with zero additional configuration. Directus would remain fully supported for production deployments.
+>
+> Until this is implemented, see the [Henn Auth Template](https://github.com/ABCHai25/Henn_Auth_Template) alternative above, or contribute to this effort by opening a pull request.
+
+## Usage Guide
 
 ### Step 1: Authentication
 
 1. Navigate to `http://localhost:3001` (or your deployed URL)
-2. **New users:** Click "Register" and create an account
+2. **New users:** Click "Register", fill in your details, and accept the data consent checkbox
 3. **Existing users:** Enter your email and password to log in
 4. Click "Enter Application" on the welcome page
 
@@ -270,7 +297,7 @@ The extension automatically:
 
 ![Extended Tile Tab](./public/project_page2.png)
 
-Forma limits terrain to ~2km × 2km. To detect trees beyond this limit:
+Forma limits terrain to ~2km x 2km. To detect trees beyond this limit:
 
 1. Go to the **"Extend Project"** tab
 2. Enter extension distances in meters (North, East, South, West)
@@ -291,33 +318,35 @@ Results show:
 - Number of trees detected
 - Individual tree coordinates
 - Estimated diameters and heights
-- Elevation of each tree
+- Elevation of each tree (fetched concurrently with retry logic)
 
 ### Step 5: Place Trees in Forma
 
 1. Review detected trees in the list
-2. Adjust the **Tree Model Scale** if needed
+2. Adjust the **density slider** to control what percentage of detected trees to place
 3. Click **"Place Trees"**
 
-Trees are placed using **instance mode** for maximum performance:
+Trees are placed using the **batch `updateElements` API** for maximum performance:
 - Single 3D model definition uploaded once
-- Thousands of instances placed at 40+ trees/second
+- All instances sent in batches of 500 operations
+- ~3,000 trees placed in ~10 seconds
 - Each tree scaled according to its detected diameter
+- Trees with invalid elevation (NaN or zero) are automatically excluded
 
 ### Step 6: Export Options
 
-- **📦 Download OBJ** - 3D model with trees on textured ground (for Rhino, Blender)
-- **📥 Download JSON** - Raw detection data with coordinates
+- **Download OBJ** - 3D model with all detected trees (uses a two-step generate + streaming download, supports files over 242MB)
+- **Download JSON** - Raw detection data with coordinates
 
-## 🧮 How It Works
+## How It Works
 
 ### Satellite Imagery Pipeline
 
 1. **Coordinate Transformation**: Convert Forma's UTM terrain bounds to WGS84 (lat/lon) using proj4
 2. **Zoom Calculation**: Determine optimal tile resolution (~0.6-0.8 m/pixel at zoom 18)
-3. **Tile Fetching**: Download grid of 512×512px Mapbox raster tiles
+3. **Tile Fetching**: Download grid of 512x512px Mapbox raster tiles
 4. **Stitching & Cropping**: Combine tiles and crop to exact boundaries
-5. **Perspective Warping**: Apply homography to correct Web Mercator → UTM distortions
+5. **Perspective Warping**: Apply homography to correct Web Mercator to UTM distortions
 
 ### Tree Detection Algorithm
 
@@ -328,23 +357,37 @@ The Python backend uses **HSV color segmentation**:
 4. Calculate centroid and diameter for each tree
 5. Return coordinates in both pixels and meters
 
-### Tree Placement (Instance Mode)
+### OBJ Model Generation (Two-Step Export)
 
-Instead of creating thousands of separate 3D models (slow and bloated), we use **true instancing**:
+Large tree models (20k+ trees, 242MB+) are handled with a two-step architecture:
+
+1. **`POST /api/generate-model`** — sends detection data to the Python backend, which generates the OBJ file, saves it to a temp directory, and returns JSON metadata (filename, file size, tree/vertex/face counts).
+2. **`GET /api/download-model/:filename`** — Express streams the file from Python directly to the browser with no in-memory buffering, allowing reliable downloads of very large files.
+
+### Batch Tree Placement
+
+Instead of placing trees one at a time (slow), we use Forma's **batch `updateElements` API**:
 
 ```
-Traditional: 1,000 trees = 1,000 element definitions ❌ (slow)
-Instance Mode: 1,000 trees = 1 definition + 1,000 instances ✅ (fast)
+One-at-a-time:  3,000 trees ~ 17 minutes  (slow)
+Batch mode:     3,000 trees ~ 10 seconds   (fast)
 ```
 
-**Performance:** 40+ trees/second placement speed
+Operations are built upfront as an array of placement commands, then sent in sequential batches of 500. At 100% density, trees are shuffled randomly before placement to avoid spatial bias.
+
+### Elevation Fetching
+
+Tree elevations are fetched from Forma's terrain data using two strategies:
+
+- **1,500 trees or fewer**: Direct fetch via `Forma.terrain.getElevationAt()` per tree
+- **More than 1,500 trees**: Grid interpolation — a 10x10 elevation grid is fetched concurrently (15 parallel workers, up to 3 retries per point with 100/200/300ms backoff), then individual tree elevations are bilinearly interpolated from the grid
 
 ### Per-Tree Scaling
 
 Each tree is scaled based on its detected canopy diameter:
 - **Diameter** = measured from satellite imagery (meters)
-- **Height** = diameter × 1.5 (realistic proportion)
-- **Scale factor** = calculated to match the base tree model
+- **Height** = diameter x 1.5 (realistic proportion)
+- **Scale factor** = calculated to match the base tree model (12m tall)
 
 This creates natural variation in tree sizes across your project.
 
@@ -358,15 +401,15 @@ The "Extend Project" feature allows coverage beyond Forma's terrain limits:
 
 ### Continuous Integration (GHCR Builds)
 
-Every push to the `main` branch now triggers `.github/workflows/build-ghcr.yml`, a GitHub Actions workflow that automatically:
+Every push to the `main` branch triggers `.github/workflows/build-ghcr.yml`, a GitHub Actions workflow that automatically:
 1. Builds the React/Express image from `Dockerfile`
 2. Builds the Python FastAPI image from `python_backend/Dockerfile`
 3. Tags both images (commit SHA + `latest` on main)
-4. Pushes them to GitHub Container Registry (`ghcr.io/abchai25`)
+4. Pushes them to GitHub Container Registry (`ghcr.io`)
 
 #### Required Repository Secrets
 
-Add these secrets under **GitHub Repo → Settings → Secrets and variables → Actions**:
+Add these secrets under **GitHub Repo > Settings > Secrets and variables > Actions**:
 
 | Secret | Description |
 |--------|-------------|
@@ -375,80 +418,89 @@ Add these secrets under **GitHub Repo → Settings → Secrets and variables →
 
 Once configured, simply `git push origin main` to publish fresh container images without any local Docker commands.
 
-## 📁 Project Structure
+## Project Structure
 
 ```
-my-react-forma/
+forma-extension-trees/
 ├── src/
-│   ├── App.tsx                        # Main application with navigation
+│   ├── App.tsx                        # Main application with tab navigation
+│   ├── App.css                        # App styles + font-face declarations
+│   ├── index.css                      # Global styles (light theme)
 │   ├── components/
 │   │   ├── ActionButtons.tsx          # Project info & fetch buttons
 │   │   ├── ExtendProjectPanel.tsx     # Extended tile controls
 │   │   ├── MapboxTilePanel.tsx        # Satellite tile display
-│   │   ├── TreeListPanel.tsx          # Detection results & placement
-│   │   ├── TreePlacementTester.tsx    # Instance mode placement
-│   │   ├── UserMenu.tsx               # Navigation dropdown
-│   │   └── MyProjectsPage.tsx         # Project history page
+│   │   ├── TreeListPanel.tsx          # Detection results & OBJ export
+│   │   ├── TreePlacementTester.tsx    # Batch placement with density control
+│   │   ├── ModelResultPanel.tsx       # Download result metadata
+│   │   ├── UserMenu.tsx              # User dropdown menu
+│   │   └── MyProjectsPanel.tsx        # Slide-in projects drawer
 │   ├── hooks/
 │   │   ├── useFormaProject.ts         # Project metadata management
 │   │   ├── useMapboxTile.ts           # Tile fetching & warping
 │   │   └── useTreePipeline.ts         # Detection pipeline
 │   ├── services/
 │   │   ├── directus.service.ts        # Directus API client
+│   │   ├── elevation.service.ts       # Concurrent elevation fetching
+│   │   ├── modelGeneration.service.ts # Two-step OBJ generate + download
 │   │   └── ...
-│   └── main.tsx                       # Entry point
+│   ├── fonts/
+│   │   ├── NBGROTESK-REGULAR.OTF     # Custom font (bundled by Vite)
+│   │   └── NBGROTESK-BOLD.OTF        # Custom font (bundled by Vite)
+│   └── main.tsx                       # Entry point (Forma iframe check)
 ├── backend/
-│   ├── index.js                       # Express server
+│   ├── index.js                       # Express server + download proxy
 │   ├── auth-setup.js                  # Authentication configuration
 │   ├── passport-config.js             # Passport.js setup
 │   ├── routes/                        # API routes
 │   │   └── auth.js                    # Auth endpoints
 │   ├── services/
 │   │   ├── directus.js                # Directus integration
-│   │   └── email.js                   # Email service (password reset)
-│   └── middleware/                    # Express middleware
+│   │   └── email.js                   # Email service
+│   └── middleware/                     # Express middleware
 ├── python_backend/
-│   ├── main.py                        # FastAPI server
+│   ├── main.py                        # FastAPI server + download endpoint
 │   ├── Dockerfile                     # Python container
 │   ├── tree_detector_core.py          # Detection algorithm
-│   └── model_generator_core.py        # OBJ/GLB generation
+│   └── model_generator_core.py        # OBJ generation (temp file output)
 ├── .github/
 │   └── workflows/
 │       └── build-ghcr.yml             # CI workflow (build & push images)
 ├── public/
-│   ├── login.html                     # Login page
-│   ├── register.html                  # Registration page
+│   ├── login.html                     # Login page (with password toggle)
+│   ├── register.html                  # Registration page (with GDPR consent)
 │   ├── welcome.html                   # Welcome page
-│   └── forgot-password.html           # Password reset (Placeholder for now)
+│   └── forgot-password.html           # Password reset (placeholder)
 ├── Dockerfile                         # Backend + Frontend container
 ├── docker-compose.yml                 # Container orchestration
+├── docker-compose.production.yml      # Production with nginx
+├── nginx.conf                         # Production proxy (port 8012)
 ├── .env.example                       # Environment template
 └── README.md
 ```
 
-## 🔑 Environment Variables
+## Environment Variables
 
 ### Root `.env`
 ```bash
 # Required
-VITE_MAPBOX_TOKEN=pk.xxx              # Mapbox API token
+VITE_MAPBOX_TOKEN=pk.xxx              # Mapbox API token (baked into frontend build)
 DIRECTUS_URL=https://your-instance    # Directus URL
 DIRECTUS_STATIC_TOKEN=xxx             # Directus API token
+SESSION_SECRET=your-secure-secret     # Session encryption key
+
+# Required for production (Forma iframe)
+ALLOWED_ORIGINS=https://app.autodeskforma.eu  # Comma-separated CORS origins
+SESSION_COOKIE_SECURE=true            # Must be true for HTTPS
+SESSION_COOKIE_SAMESITE=none          # Must be 'none' for cross-origin iframe
 
 # Optional
-VITE_API_BASE_URL=http://localhost:3001
-SESSION_SECRET=your-secure-secret
+PYTHON_API_URL=http://localhost:5001  # Default Python backend URL
+NODE_ENV=production                   # Set in Docker
+PORT=3001
 ```
 
-### Backend `.env`
-```bash
-DIRECTUS_URL=https://your-instance
-DIRECTUS_STATIC_TOKEN=xxx
-SESSION_SECRET=your-secure-secret
-PYTHON_API_URL=http://localhost:5001
-```
-
-## 🐳 Docker Commands
+## Docker Commands
 
 ```bash
 # Build and start all services
@@ -472,39 +524,60 @@ docker-compose build backend
 docker-compose build python-api
 ```
 
-## 📊 Performance
+## Performance
 
 | Operation | Time |
 |-----------|------|
 | Tile fetching (2km bbox) | 2-20 seconds |
 | Tree detection (standard) | 2-5 seconds |
 | Tree detection (5km extended) | 60-120 seconds |
-| Tree placement | 40+ trees/second |
+| Tree placement (3,000 trees) | ~10 seconds |
+| Elevation fetch (grid, >1500 trees) | ~2.5 minutes |
 
 ### Limits
 
-- **Maximum recommended extended tile:** 5km × 5km
-- **Maximum trees per placement:** ~60,000 (larger creates unstable files)
-- **Detection timeout:** 10 minutes
-- **Model generation timeout:** 5 minutes
+| Item | Limit |
+|------|-------|
+| Maximum recommended extended tile | 5km x 5km |
+| Maximum trees per placement batch | 3,000 |
+| Maximum trees for OBJ export | 60,000 |
+| Detection timeout | 10 minutes |
+| Model generation timeout | 10 minutes |
+| File upload / request body | 50 MB |
 
-## 🐛 Troubleshooting
+## API Endpoints
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `POST` | `/api/detect-trees` | Detect trees from uploaded satellite image |
+| `POST` | `/api/generate-model` | Generate OBJ model, returns JSON metadata |
+| `GET` | `/api/download-model/:filename` | Stream generated OBJ file to browser |
+| `POST` | `/api/login` | Authenticate user |
+| `POST` | `/api/register` | Create new user account |
+| `GET` | `/api/user` | Get current user info |
+| `POST` | `/api/logout` | End session |
+| `GET` | `/health` | Health check (Express + Python) |
+
+## Troubleshooting
 
 | Issue | Solution |
 |-------|----------|
 | CORS errors on tile fetch | Check Mapbox token is set in `.env` |
+| CORS errors in Forma iframe | Add Forma origin to `ALLOWED_ORIGINS` and set `SESSION_COOKIE_SAMESITE=none` |
 | "DIRECTUS_URL missing" | Add `DIRECTUS_URL` to your `.env` file |
 | Container unhealthy | Run `docker-compose logs` to check errors |
 | Trees not detected | Adjust HSV thresholds for your imagery |
-| Slow tree placement | Normal for large projects (rate limiting) |
+| OBJ download fails for large files | Should now work with streaming — check Python temp dir has disk space |
+| Only partial trees placed | Trees with invalid elevation (NaN/zero) are excluded — check terrain coverage |
 
-## 📚 Additional Resources
+## Additional Resources
 
 - **Forma Embedded Views:** https://aps.autodesk.com/en/docs/forma/v1/embedded-views/introduction/
+- **Forma Extensions Tutorial:** https://tutorials.autodesk.com/courses/forma-extensions-tutorial
 - **Mapbox Raster Tiles:** https://docs.mapbox.com/api/maps/raster-tiles/
 - **proj4 Documentation:** http://proj4.org/
 
-## 🤝 Contributing
+## Contributing
 
 Contributions welcome! To contribute:
 
@@ -514,17 +587,10 @@ Contributions welcome! To contribute:
 4. Push to branch (`git push origin feature/AmazingFeature`)
 5. Open Pull Request
 
-### Areas for Improvement
-
-- [ ] GPU-accelerated warping (WebGL)
-- [ ] Batch processing multiple projects
-- [ ] Additional tree model variations
-- [ ] Integration with other Forma elements
-
-## 📄 License
+## License
 
 MIT License - see LICENSE file for details
 
 ---
 
-*Last Updated: 08 December 2025*
+*Last Updated: 12 April 2026*

--- a/backend/index.js
+++ b/backend/index.js
@@ -77,6 +77,11 @@ setupAuth(app);
 // Serve static files from public folder (login.html, welcome.html, etc.)
 app.use(express.static(path.join(__dirname, '../public')));
 
+// Data protection policy page (clean URL)
+app.get('/privacy', (req, res) => {
+  res.sendFile(path.join(__dirname, '../public', 'data-protection-policy.html'));
+});
+
 // Directory paths (used for legacy tile saving - now tiles are downloaded directly by user)
 const TILES_DIR = path.join(__dirname, '../fetched_tiles');
 const SEGMENTATION_DIR = path.join(__dirname, '../segmentation_output');

--- a/public/data-protection-policy.html
+++ b/public/data-protection-policy.html
@@ -1,0 +1,382 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Data Protection Policy – HENN Tree Detection App</title>
+    <style>
+        @font-face {
+            font-family: 'NB Grotesk';
+            src: url('fonts/NBGROTESK-REGULAR.OTF') format('opentype');
+            font-weight: normal;
+        }
+
+        @font-face {
+            font-family: 'NB Grotesk';
+            src: url('fonts/NBGROTESK-BOLD.OTF') format('opentype');
+            font-weight: bold;
+        }
+
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: 'NB Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            background: #f5f5f5;
+            color: #1a1a1a;
+            line-height: 1.7;
+            font-size: 15px;
+        }
+
+        header {
+            background: #f5510a;
+            color: white;
+            padding: 24px 40px;
+            display: flex;
+            align-items: center;
+            gap: 28px;
+        }
+
+        header .logo-link {
+            display: inline-flex;
+            align-items: center;
+            text-decoration: none;
+            transition: opacity 0.2s;
+        }
+
+        header .logo-link:hover {
+            opacity: 0.8;
+        }
+
+        header img {
+            height: 56px;
+            filter: brightness(0) invert(1);
+        }
+
+        header h1 {
+            font-size: 20px;
+            font-weight: bold;
+            letter-spacing: 0.01em;
+        }
+
+        header .company-link {
+            margin-left: auto;
+            color: white;
+            font-size: 14px;
+            font-weight: 500;
+            text-decoration: none;
+            padding: 8px 16px;
+            border: 1px solid rgba(255, 255, 255, 0.5);
+            border-radius: 6px;
+            transition: background 0.2s, border-color 0.2s;
+            white-space: nowrap;
+        }
+
+        header .company-link:hover {
+            background: rgba(255, 255, 255, 0.15);
+            border-color: white;
+        }
+
+        .container {
+            max-width: 820px;
+            margin: 48px auto;
+            padding: 0 24px 80px;
+        }
+
+        .meta {
+            color: #666;
+            font-size: 13px;
+            margin-bottom: 40px;
+            padding-bottom: 24px;
+            border-bottom: 1px solid #ddd;
+        }
+
+        h2 {
+            font-size: 20px;
+            font-weight: bold;
+            margin: 40px 0 12px;
+            color: #1a1a1a;
+        }
+
+        h3 {
+            font-size: 16px;
+            font-weight: bold;
+            margin: 28px 0 8px;
+            color: #1a1a1a;
+        }
+
+        p {
+            margin-bottom: 14px;
+            color: #333;
+        }
+
+        .toc {
+            background: white;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 24px 28px;
+            margin-bottom: 40px;
+        }
+
+        .toc h2 {
+            margin-top: 0;
+            font-size: 16px;
+            margin-bottom: 12px;
+        }
+
+        .toc ol {
+            padding-left: 20px;
+        }
+
+        .toc li {
+            margin-bottom: 6px;
+            font-size: 14px;
+        }
+
+        .toc a {
+            color: #f5510a;
+            text-decoration: none;
+        }
+
+        .toc a:hover {
+            text-decoration: underline;
+        }
+
+        .contact-block {
+            background: white;
+            border: 1px solid #e0e0e0;
+            border-radius: 8px;
+            padding: 20px 24px;
+            margin: 12px 0 20px;
+            font-size: 14px;
+            line-height: 1.8;
+            color: #333;
+        }
+
+        .contact-block strong {
+            display: block;
+            margin-bottom: 4px;
+            color: #1a1a1a;
+        }
+
+        .rights-list {
+            list-style: none;
+            padding: 0;
+        }
+
+        .rights-list li {
+            border-left: 3px solid #f5510a;
+            padding: 12px 16px;
+            margin-bottom: 12px;
+            background: white;
+            border-radius: 0 6px 6px 0;
+        }
+
+        .rights-list li strong {
+            display: block;
+            margin-bottom: 4px;
+            color: #1a1a1a;
+        }
+
+        a {
+            color: #f5510a;
+        }
+
+        hr {
+            border: none;
+            border-top: 1px solid #ddd;
+            margin: 40px 0;
+        }
+    </style>
+</head>
+
+<body>
+
+    <header>
+        <a href="https://www.henn.com/" target="_blank" rel="noopener noreferrer" class="logo-link" aria-label="HENN company website">
+            <img src="logo-HENN.png" alt="HENN Logo">
+        </a>
+        <h1>Forma Extension Data Protection Policy</h1>
+        <a href="https://www.henn.com/" target="_blank" rel="noopener noreferrer" class="company-link">Link to Company website &rarr;</a>
+    </header>
+
+    <div class="container">
+
+        <p class="meta">HENN Tree Detection App &nbsp;·&nbsp; Last updated: April 2026</p>
+
+        <div class="toc">
+            <h2>Table of Contents</h2>
+            <ol>
+                <li><a href="#s1">General information and principles of data processing</a></li>
+                <li><a href="#s2">Controller</a></li>
+                <li><a href="#s3">Data Protection Officer</a></li>
+                <li><a href="#s4">Use of the App / Technical Provision</a></li>
+                <li><a href="#s5">Use of cookies (Cookie policy)</a></li>
+                <li><a href="#s6">Data security and security measures</a></li>
+                <li><a href="#s7">Your rights (as a data subject)</a></li>
+                <li><a href="#s8">Changes to this privacy policy</a></li>
+            </ol>
+        </div>
+
+        <!-- Section 1 -->
+        <h2 id="s1">1. General information and principles of data processing</h2>
+
+        <p>We are pleased that you are using our app. The protection of your privacy and your personal data is important to us. Pursuant to Article 4(1) of the General Data Protection Regulation (GDPR), personal data means all information relating to an identified or identifiable natural person. This includes, for example, a user's name, email address, or other identifiers. Data that cannot be linked to an identifiable individual is not considered personal data.</p>
+
+        <p>Personal data is processed (e.g. collected, stored, used, or deleted) exclusively in accordance with the applicable legal provisions, in particular the GDPR. Personal data is deleted as soon as the purpose of the processing has been fulfilled and no statutory retention obligations apply.</p>
+
+        <p>This privacy policy informs you about the nature, scope, purpose, legal basis, and storage duration of the processing of personal data in connection with the use of our app.</p>
+
+        <p>The app is an extension of the online platform "Forma Site Design" operated by Autodesk, Inc. Use of the app requires users to already have an Autodesk user account and to have accepted Autodesk's privacy policies. We have no influence on data processing carried out by Autodesk. In this respect, Autodesk's privacy policies apply.</p>
+
+        <hr>
+
+        <!-- Section 2 -->
+        <h2 id="s2">2. Controller</h2>
+
+        <p>Responsible for the processing of personal data is:</p>
+
+        <div class="contact-block">
+            <strong>Henn GmbH</strong>
+            Augustenstr. 54<br>
+            80333 München<br>
+            Tel.: +49 (0)89 52 35 7-0<br>
+            E-Mail: <a href="mailto:info@henn.com">info@henn.com</a>
+        </div>
+
+        <hr>
+
+        <!-- Section 3 -->
+        <h2 id="s3">3. Data Protection Officer</h2>
+
+        <p>If you have any further questions regarding data protection, please feel free to contact our data protection officer:</p>
+
+        <div class="contact-block">
+            <strong>Robert Faußner, M.A. — Protection Officer</strong>
+            c/o HEUSSEN Rechtsanwaltsgesellschaft mbH<br>
+            Brienner Straße 9 / Amiraplatz<br>
+            80333 Munich, Germany<br>
+            Tel.: +49 89 290 97 0<br>
+            Fax: +49 89 290 97 200<br>
+            E-Mail: <a href="mailto:robert.faussner@heussen-law.de">robert.faussner@heussen-law.de</a>
+        </div>
+
+        <hr>
+
+        <!-- Section 4 -->
+        <h2 id="s4">4. Use of the App / Technical Provision</h2>
+
+        <h3>Type and extent of data processing</h3>
+
+        <p>The app consists of two technical components: an integration and extension layer operated by Autodesk, and a backend and business logic layer operated by us. User inputs are initially transmitted to the integration layer operated by Autodesk and are subsequently forwarded to our servers.</p>
+
+        <p>In the course of using the app, we process in particular the following data: user agent information (browser type, version, and operating system), timestamps of requests, and technically necessary usage data (payload) required to execute the requested app functionality. We do not process or store the user's IP address. All requests to our servers are transmitted via Autodesk's infrastructure and display uniform source IP addresses.</p>
+
+        <p>Furthermore, in order to provide the services of the app, we may process the following identifiers: a unique device identification number, network subscriber information (IMSI), mobile phone number (MSISDN), MAC address for WLAN use, device name, and email address.</p>
+
+        <h3>Purpose of data processing</h3>
+
+        <p>The processing of the aforementioned data is carried out in order to technically provide the app, execute the functions requested by the user, and ensure the stability, security, and error-free operation of the app.</p>
+
+        <p>The app includes user and project management functionality. In this context, the following personal data is processed in particular: user identifier or username, login information, and project names. This data is stored in a database on HENN's servers. To protect against unauthorized access and, in particular, against SQL injection attacks, an additional security and abstraction layer is implemented.</p>
+
+        <h3>Legal basis</h3>
+
+        <p>The legal basis for the processing of personal data is Article 6(1)(b) GDPR (performance of the user relationship) as well as Article 6(1)(f) GDPR (legitimate interest in the secure and fully functional provision of the app). Where technically necessary cookies or comparable technologies are used in the course of using the app, this is carried out on the basis of Section 25(2) No. 2 of the German Telecommunications-Telemedia Data Protection Act (TDDDG).</p>
+
+        <h3>Storage period</h3>
+
+        <p>Personal data from user and project management is generally stored for as long as a user account or the respective project exists, and is subsequently deleted unless required by law to be retained. Technical log data and usage logs are processed exclusively for the purposes of error analysis and system security and are stored only for as long as necessary for these purposes. Deletion occurs regularly, typically within a period of up to 30 days.</p>
+
+        <h3>Recipients of personal data</h3>
+
+        <p>The data may be accessed by Autodesk, Inc., The Landmark @ One Market, Suite 400, San Francisco, CA 94105, USA. This is necessary for the use of the service. A data processing agreement has been concluded with Autodesk, Inc. Personal data may be transferred to the United States in compliance with the law, as an adequacy decision exists for the United States and Autodesk, Inc. is certified under the EU–U.S. Data Privacy Framework (EU-US DPF): <a href="https://www.dataprivacyframework.gov/list" target="_blank" rel="noopener noreferrer">https://www.dataprivacyframework.gov/list</a></p>
+
+        <h3>Right of objection</h3>
+
+        <p>Where your personal data is processed on the basis of Article 6(1), first sentence, point (f) GDPR, you generally have the right to object pursuant to Article 21 GDPR. In the context of the specific processing operation, our legitimate interests usually prevail, as the app cannot be properly provided and operated without the processing of this data.</p>
+
+        <hr>
+
+        <!-- Section 5 -->
+        <h2 id="s5">5. Use of cookies (Cookie policy)</h2>
+
+        <p>In the course of using the app, only technically necessary cookies are used. These cookies are required to provide basic functionalities of the app (e.g. session management). No tracking, analytics, or marketing cookies are used. The legal basis is Section 25(2) No. 2 TDDDG as well as Article 6(1), first sentence, point (f) GDPR. Without these cookies, the app cannot be operated properly.</p>
+
+        <hr>
+
+        <!-- Section 6 -->
+        <h2 id="s6">6. Data security and security measures</h2>
+
+        <p>We are committed to protecting your privacy and treating your personal data confidentially. For this purpose, we take extensive technical and organisational security precautions, which are regularly checked and adapted to technological progress. These include the use of recognized encryption procedures (SSL or TLS).</p>
+
+        <p>Unencrypted data, e.g. when sent by unencrypted e-mail, may be read by third parties. We have no influence on this. It is the responsibility of the respective user to protect the data provided by them against misuse by means of encryption or in any other way.</p>
+
+        <hr>
+
+        <!-- Section 7 -->
+        <h2 id="s7">7. Your rights (as a data subject)</h2>
+
+        <p>Here you will find your rights regarding your personal data. Details of this are set out in Articles 7, 15–22 and 77 of the GDPR. You can contact the controller (Section 2) or the data protection officer (Section 3) in this regard.</p>
+
+        <ul class="rights-list">
+            <li>
+                <strong>7.1 Right to withdraw consent — Article 7(3) GDPR</strong>
+                You can withdraw your consent to the processing of your personal data at any time with effect for the future. The withdrawal of consent shall not affect the lawfulness of processing based on consent before its withdrawal.
+            </li>
+            <li>
+                <strong>7.2 Right of access — Article 15 GDPR in conjunction with § 34 BDSG</strong>
+                You have the right to request confirmation as to whether we process personal data concerning you. If this is the case, you have the right to be informed about your personal data and to receive further information, e.g. the purposes of processing, the categories of personal data processed, the recipients and the planned duration of storage.
+            </li>
+            <li>
+                <strong>7.3 Right to rectification and completion — Article 16 GDPR</strong>
+                You have the right to demand the correction of incorrect data without delay. Taking into account the purposes of the processing, you have the right to request the completion of incomplete data.
+            </li>
+            <li>
+                <strong>7.4 Right to erasure ("right to be forgotten") — Article 17 GDPR in conjunction with § 35 BDSG</strong>
+                You have the right of erasure, as far as the processing is not necessary. This is the case, for example, if your data is no longer necessary for the original purposes, if you have withdrawn your declaration of consent under data protection law, or if the data was processed unlawfully.
+            </li>
+            <li>
+                <strong>7.5 Right to restriction of processing — Article 18 GDPR</strong>
+                You have the right to limit the processing, for example if you believe that personal data is incorrect.
+            </li>
+            <li>
+                <strong>7.6 Right to data portability — Article 20 GDPR</strong>
+                You have the right to receive personal data concerning you in a structured, common and machine-readable format.
+            </li>
+            <li>
+                <strong>7.7 Right to object — Article 21 GDPR</strong>
+                You have the right to object to data processing on grounds relating to particular situations. However, this only applies in cases where we process data to fulfil a legitimate interest. If you can present such a reason and we cannot assert compelling legitimate grounds for the processing which override your interests, we will no longer process this data for the respective purpose.
+            </li>
+            <li>
+                <strong>7.8 Automated individual decision-making, including profiling — Article 22 GDPR</strong>
+                You will not be subject to any decision based solely on automated processing of your data, including profiling, which produces legal effects concerning you or similarly significantly affects you.
+            </li>
+            <li>
+                <strong>7.9 Right to lodge a complaint — Article 77 GDPR</strong>
+                You can lodge a complaint with a data protection supervisory authority at any time, for example if you believe that data processing is not in compliance with data protection regulations.<br><br>
+                Competent supervisory authority:<br>
+                Bayerisches Landesamt für Datenschutzaufsicht<br>
+                Postfach 1349, 91504 Ansbach, Germany<br>
+                Phone: +49 981/180093-0 &nbsp;·&nbsp; Fax: +49 981/180093-800<br>
+                E-Mail: <a href="mailto:poststelle@lda.bayern.de">poststelle@lda.bayern.de</a><br>
+                Website: <a href="https://www.lda.bayern.de" target="_blank" rel="noopener noreferrer">https://www.lda.bayern.de</a>
+            </li>
+        </ul>
+
+        <hr>
+
+        <!-- Section 8 -->
+        <h2 id="s8">8. Changes to this privacy policy</h2>
+
+        <p>Our privacy policy serves the fulfilment of legal information duties. We update our data protection declaration as far as this becomes necessary.</p>
+
+    </div>
+
+</body>
+
+</html>

--- a/public/forgot-password.html
+++ b/public/forgot-password.html
@@ -146,7 +146,7 @@
         </p>
 
         <div class="contact-info">
-            <p>Please email <a href="mailto:info@henn.com"><strong>info@henn.com</strong></a> from the address associated with your account, and we'll get back to you as soon as possible.</p>
+            <p>Please email <a href="mailto:webtools@henn.com"><strong>webtools@henn.com</strong></a> from the address associated with your account, and we'll get back to you as soon as possible.</p>
         </div>
 
         <a href="login.html" class="btn" id="backBtn">Back to Login</a>

--- a/public/forgot-password.html
+++ b/public/forgot-password.html
@@ -86,6 +86,15 @@
             color: #f5510a;
         }
 
+        .contact-info a {
+            color: inherit;
+            text-decoration: none;
+        }
+
+        .contact-info a:hover strong {
+            text-decoration: underline;
+        }
+
         .link {
             text-align: center;
             margin-top: 20px;
@@ -133,11 +142,11 @@
         <h1>Password Reset</h1>
         
         <p class="message">
-            If you have forgotten your password, please contact the application administrator to have it reset.
+            Automated password reset isn't available yet. In the meantime, we can reset your password for you manually.
         </p>
 
         <div class="contact-info">
-            <p>Please reach out to your <strong>IT administrator</strong> or the <strong>Forma extension team</strong> for assistance with password recovery.</p>
+            <p>Please email <a href="mailto:info@henn.com"><strong>info@henn.com</strong></a> from the address associated with your account, and we'll get back to you as soon as possible.</p>
         </div>
 
         <a href="login.html" class="btn" id="backBtn">Back to Login</a>

--- a/public/login.html
+++ b/public/login.html
@@ -74,6 +74,7 @@
             font-size: 14px;
         }
 
+        input[type="text"],
         input[type="email"],
         input[type="password"] {
             width: 100%;

--- a/public/register.html
+++ b/public/register.html
@@ -205,6 +205,16 @@
             margin-top: 8px;
             display: none;
         }
+
+        .policy-link {
+            color: #f5510a;
+            text-decoration: underline;
+            font-weight: 500;
+        }
+
+        .policy-link:hover {
+            color: #d94609;
+        }
     </style>
 </head>
 
@@ -257,10 +267,10 @@
                 <label for="dataConsent">
                     <input type="checkbox" id="dataConsent">
                     <span>
-                        I agree to the storage of my <span class="consent-highlight">personal data (name, email, and projects I work on)</span> on HENN's servers in Germany. HENN will not share my personal information with any third parties.
+                        I have read and agree to the <a href="privacy" target="_blank" rel="noopener noreferrer" class="policy-link">data protection policy</a>.
                     </span>
                 </label>
-                <div class="consent-error" id="consentError">You must agree to data storage to create an account.</div>
+                <div class="consent-error" id="consentError">You must agree to the data protection policy to create an account.</div>
             </div>
 
             <button type="submit" class="btn" id="submitBtn">Create Account</button>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -15,6 +15,12 @@ export default defineConfig({
         cookieDomainRewrite: 'localhost',
         // Model generation can take minutes; download streams 200MB+
         timeout: 600000,
+      },
+      // Data protection policy route (served by Express backend)
+      '/privacy': {
+        target: 'http://localhost:3001',
+        changeOrigin: true,
+        secure: false,
       }
     }
   }


### PR DESCRIPTION
Supersedes #14 (README-only). Bundles the README update together with the work for #11 and a couple of small UI fixes surfaced during testing.

## Summary

- **README** — document Docker deployment, link to the official Forma extension tutorial, and add a note about the Directus vendor lock-in as future work.
- **Data protection policy page** (resolves #11) — new [`public/data-protection-policy.html`](../blob/main/public/data-protection-policy.html) with the full GDPR-compliant policy (Controller, DPO, processing purposes, user rights, cookies, security). Served at a clean `/privacy` URL via Express ([`backend/index.js`](../blob/main/backend/index.js)) and forwarded by the Vite dev proxy ([`vite.config.ts`](../blob/main/vite.config.ts)). The register form consent checkbox now links to it (opens in a new tab, required to create an account).
- **UI fixes**
  - `login.html`: include `input[type="text"]` in the shared input styling so the password field keeps its padding/border when the eye toggle switches its type away from `password`.
  - `forgot-password.html`: replace the internal "contact IT admin" message with DevCon-appropriate wording pointing users to `info@henn.com` for a manual reset.

## Notes for reviewers

- The `/privacy` link in the register form uses a relative path (`href="privacy"`), consistent with the rest of the codebase (e.g. `fetch('api/register', ...)`), so it works in all three deployment scenarios: Vite dev server (via proxy), Docker Compose at `localhost:8012`, and the subpath production deploy at `https://webapps.henn.com/forma-tree/`.
- The data protection policy page header links back to `https://www.henn.com/` (both the logo icon and a dedicated "Link to Company website" button).

## Test plan

- [ ] `npm run dev` — open register page, click the data protection policy link, confirm it opens `/privacy` in a new tab and renders correctly.
- [ ] `docker-compose up --build` — confirm `/privacy` is served correctly through Nginx.